### PR TITLE
add support for API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ import (
 )
 
 func main() {
+        api := gomdb.Init(YOUR_API_KEY)
 	query := &gomdb.QueryData{Title: "Macbeth", SearchType: gomdb.MovieSearch}
-	res, err := gomdb.Search(query)
+	res, err := api.Search(query)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -40,14 +41,14 @@ func main() {
 	fmt.Println(res.Search)
 
 	query = &gomdb.QueryData{Title: "Macbeth", Year: "2015"}
-	res2, err := gomdb.MovieByTitle(query)
+	res2, err := api.MovieByTitle(query)
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
 	fmt.Println(res2)
 
-	res3, err := gomdb.MovieByImdbID("tt2884018")
+	res3, err := api.MovieByImdbID("tt2884018")
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/gomdb.go
+++ b/gomdb.go
@@ -19,6 +19,14 @@ const (
 	EpisodeSearch = "episode"
 )
 
+type OmdbApi struct {
+	apiKey string
+}
+
+func Init(apiKey string) *OmdbApi {
+	return &OmdbApi{apiKey: apiKey}
+}
+
 // QueryData is the type to create the search query
 type QueryData struct {
 	Title      string
@@ -84,8 +92,8 @@ type MovieResult struct {
 }
 
 //Search for movies given a Title and year, Year is optional you can pass nil
-func Search(query *QueryData) (*SearchResponse, error) {
-	resp, err := requestAPI("search", query.Title, query.Year, query.SearchType)
+func (api *OmdbApi) Search(query *QueryData) (*SearchResponse, error) {
+	resp, err := api.requestAPI("search", query.Title, query.Year, query.SearchType)
 	if err != nil {
 		return nil, err
 	}
@@ -105,8 +113,8 @@ func Search(query *QueryData) (*SearchResponse, error) {
 }
 
 //MovieByTitle returns a MovieResult given Title
-func MovieByTitle(query *QueryData) (*MovieResult, error) {
-	resp, err := requestAPI("title", query.Title, query.Year, query.SearchType)
+func (api *OmdbApi) MovieByTitle(query *QueryData) (*MovieResult, error) {
+	resp, err := api.requestAPI("title", query.Title, query.Year, query.SearchType)
 	if err != nil {
 		return nil, err
 	}
@@ -125,8 +133,8 @@ func MovieByTitle(query *QueryData) (*MovieResult, error) {
 }
 
 //MovieByImdbID returns a MovieResult given a ImdbID ex:"tt2015381"
-func MovieByImdbID(id string) (*MovieResult, error) {
-	resp, err := requestAPI("id", id)
+func (api *OmdbApi) MovieByImdbID(id string) (*MovieResult, error) {
+	resp, err := api.requestAPI("id", id)
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +156,7 @@ func MovieByImdbID(id string) (*MovieResult, error) {
 // param: apiCategory refers to which API we are calling. Can be "search", "title" or "id"
 // Depending on that value, we will search by "t" or "s" or "i"
 // param: params are the variadic list of params passed for that category
-func requestAPI(apiCategory string, params ...string) (resp *http.Response, err error) {
+func (api *OmdbApi) requestAPI(apiCategory string, params ...string) (resp *http.Response, err error) {
 	var URL *url.URL
 	URL, err = url.Parse(baseURL)
 	if err != nil {
@@ -165,6 +173,8 @@ func requestAPI(apiCategory string, params ...string) (resp *http.Response, err 
 	}
 	URL.Path += "/"
 	parameters := url.Values{}
+	parameters.Add("apikey", api.apiKey)
+
 	switch apiCategory {
 	case "search":
 		parameters.Add("s", params[0])

--- a/gomdb_test.go
+++ b/gomdb_test.go
@@ -1,6 +1,25 @@
 package gomdb
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
+
+var apiKey = os.Getenv("OMDB_API_KEY")
+
+func TestNoKey(t *testing.T) {
+	api := Init("")
+	_, err := api.Search(&QueryData{Title: "Her"})
+	if err == nil {
+		t.Errorf("Expected to fail")
+	}
+	if err != nil {
+		expectedErrorMsg := "Status Code 401 received from IMDB"
+		if err.Error() != expectedErrorMsg {
+			t.Errorf("Expected- %s, Got- %s", expectedErrorMsg, err)
+		}
+	}
+}
 
 func TestSearch(t *testing.T) {
 	tests := []struct {
@@ -21,9 +40,9 @@ func TestSearch(t *testing.T) {
 			"2015",
 		},
 	}
-
+	api := Init(apiKey)
 	for i, item := range tests {
-		resp, err := Search(item.query)
+		resp, err := api.Search(item.query)
 		if err != nil {
 			t.Errorf("Test[%d]: %s", i, err)
 			continue
@@ -47,8 +66,9 @@ func TestFailSearch(t *testing.T) {
 		{&QueryData{Title: "Dexter", SearchType: EpisodeSearch}},
 	}
 
+	api := Init(apiKey)
 	for i, item := range tests {
-		_, err := Search(item.query)
+		_, err := api.Search(item.query)
 		if err == nil {
 			t.Errorf("Test[%d]: Got nil error", i)
 			continue
@@ -69,8 +89,9 @@ func TestInvalidCategory(t *testing.T) {
 		{&QueryData{Title: "Dexter", SearchType: "bad"}},
 	}
 
+	api := Init(apiKey)
 	for i, item := range tests {
-		_, err := Search(item.query)
+		_, err := api.Search(item.query)
 		if err == nil {
 			t.Errorf("Test[%d]: Got nil error", i)
 			continue
@@ -103,8 +124,10 @@ func TestMovieByTitle(t *testing.T) {
 		},
 	}
 
+	api := Init(apiKey)
+
 	for i, item := range tests {
-		resp, err := MovieByTitle(item.query)
+		resp, err := api.MovieByTitle(item.query)
 		if err != nil {
 			t.Errorf("Test[%d]: %s", i, err)
 			continue
@@ -143,8 +166,10 @@ func TestMovieByImdbID(t *testing.T) {
 		},
 	}
 
+	api := Init(apiKey)
+
 	for i, item := range tests {
-		resp, err := MovieByImdbID(item.id)
+		resp, err := api.MovieByImdbID(item.id)
 		if err != nil {
 			t.Errorf("Test[%d]: %s", i, err)
 			continue


### PR DESCRIPTION
As you might know, the API now requires a key, that can be obtained by becoming a suporter. Current version of library does not work anymore ( Issue #11 ).

Unit tests are getting the key from environment:
`var apiKey = os.Getenv("OMDB_API_KEY")`

This also means that one will have to  [configure the environment variable in TravisCI](https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings).